### PR TITLE
Offer Homebrew first in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@
 
 ## Install
 
-1. Download the latest DMG from [**Releases**](../../releases/latest) (or start at the [website](https://loadout.migsilva.dev)).
-2. Open it and drag **Loadout** to **Applications**.
+```bash
+brew install --cask migsilva89/loadout/loadout
+```
 
-Requires macOS 15 or newer. The build is signed and notarised, so it opens without a warning and
-without a trip through System Settings.
+Or download the [latest release](../../releases/latest) — the [website](https://loadout.migsilva.dev)
+points at the same file — and drag `Loadout.app` into `/Applications`. The disk image is signed and
+notarised, so it opens without a Gatekeeper warning and without a trip through System Settings.
+
+macOS 15 or later.
 
 Or build it yourself, which needs Xcode:
 


### PR DESCRIPTION
Rewrites the README's Install section so `brew install --cask migsilva89/loadout/loadout` is the first thing offered, with the signed disk image as the alternative.
The tap went live and nothing in the repository mentioned it, so the shortest way to install the app was also the only undocumented one.