### PR TITLE
Fix Ask with Codex, duplicated skills, an impossible removal, and dishonest update checks

### DIFF
--- a/Sources/LoadoutApp/DetailView.swift
+++ b/Sources/LoadoutApp/DetailView.swift
@@ -866,51 +866,71 @@ struct DetailView: View {
     private var cardWidth: CGFloat { paneWidth - Self.cardMargins * 2 }
     private static let cardMargins: CGFloat = 24
 
+    @ViewBuilder
     private func assistantCell(_ assistant: Assistant, item: Item) -> some View {
         let has = item.assistants.contains(assistant.id)
         let none = !has && !assistant.hasSkillsFolder
-        return Button {
-            model.setAssistant(assistant, on: item, present: !has)
-        } label: {
-            HStack(spacing: 9) {
-                AssistantMark(assistant: assistant, present: has || !none, size: 20)
-                Text(assistant.label)
-                    .font(.system(size: 12.5))
-                    .foregroundStyle(Color.white.opacity(none ? 0.4 : 0.88))
-                    .lineLimit(1)
-                    .fixedSize()
-                // Beside the name, not out in the state column: it belongs to this assistant,
-                // and against the column it read as part of the word next to it.
-                if let count = assistantUsage[assistant.id], count > 0 {
-                    Text("\(count)")
-                        .font(.system(size: 11))
-                        .monospacedDigit()
-                        .foregroundStyle(V2.textFaint)
-                        .fitsOnOneLine()
-                }
-                Spacer(minLength: 6)
-                // One glyph per state, all the same size and shape, so the column reads as a
-                // column. Colour still carries the meaning at a distance — the healthy hue for
-                // carried, the link hue for available, grey for nothing to carry it with — and
-                // the words move to the tooltip, where the space is free. It also stops "loaded"
-                // from stacking into three letters when the grid squeezes to four up.
-                Image(systemName: has ? "checkmark.circle.fill" : (none ? "minus.circle" : "plus.circle"))
-                    .font(.system(size: 13))
-                    .foregroundStyle(has ? V2.ok : (none ? V2.muted : V2.link))
+        // The one assistant that holds the last copy: unlinking there would take the skill with
+        // it, so the row never becomes a click. `Mutations.unshare` refuses the same thing, but
+        // refusing after the click means the app offered something it could not do. Read off the
+        // live item, so the moment a second assistant loads the skill this row is a button again.
+        let onlyCopy = has && item.assistants.count == 1
+
+        if onlyCopy {
+            // Still reads as loaded — the check is true and worth seeing. Only the removal is
+            // gone, dimmed the way a disabled control is.
+            assistantRow(assistant, has: has, none: none)
+                .help("Only copy — removing it would delete the skill. Disable it instead.")
+                .opacity(0.55)
+                .spotlight(Spotlight.assistant(assistant.id))
+        } else {
+            Button {
+                model.setAssistant(assistant, on: item, present: !has)
+            } label: {
+                assistantRow(assistant, has: has, none: none)
+                    // On the content, not on the Button around it. A plain-styled button hands its
+                    // tracking area to the label, and a tooltip hung outside that never fires —
+                    // which is why no cell in this grid had one, whatever it showed.
+                    .help(assistantHelp(assistant, has: has))
             }
-            .padding(.horizontal, 13)
-            .padding(.vertical, 9)
-            .overlay(alignment: .bottom) { Hairline(color: Color.white.opacity(0.06)) }
-            .overlay(alignment: .trailing) { Hairline(color: Color.white.opacity(0.06), vertical: true) }
-            .contentShape(Rectangle())
-            // On the content, not on the Button around it. A plain-styled button hands its
-            // tracking area to the label, and a tooltip hung outside that never fires — which is
-            // why no cell in this grid had one, whatever it showed.
-            .help(assistantHelp(assistant, has: has))
+            .buttonStyle(.plain)
+            .pointingHand()
+            .spotlight(Spotlight.assistant(assistant.id))
         }
-        .buttonStyle(.plain)
-        .pointingHand()
-        .spotlight(Spotlight.assistant(assistant.id))
+    }
+
+    private func assistantRow(_ assistant: Assistant, has: Bool, none: Bool) -> some View {
+        HStack(spacing: 9) {
+            AssistantMark(assistant: assistant, present: has || !none, size: 20)
+            Text(assistant.label)
+                .font(.system(size: 12.5))
+                .foregroundStyle(Color.white.opacity(none ? 0.4 : 0.88))
+                .lineLimit(1)
+                .fixedSize()
+            // Beside the name, not out in the state column: it belongs to this assistant,
+            // and against the column it read as part of the word next to it.
+            if let count = assistantUsage[assistant.id], count > 0 {
+                Text("\(count)")
+                    .font(.system(size: 11))
+                    .monospacedDigit()
+                    .foregroundStyle(V2.textFaint)
+                    .fitsOnOneLine()
+            }
+            Spacer(minLength: 6)
+            // One glyph per state, all the same size and shape, so the column reads as a
+            // column. Colour still carries the meaning at a distance — the healthy hue for
+            // carried, the link hue for available, grey for nothing to carry it with — and
+            // the words move to the tooltip, where the space is free. It also stops "loaded"
+            // from stacking into three letters when the grid squeezes to four up.
+            Image(systemName: has ? "checkmark.circle.fill" : (none ? "minus.circle" : "plus.circle"))
+                .font(.system(size: 13))
+                .foregroundStyle(has ? V2.ok : (none ? V2.muted : V2.link))
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 9)
+        .overlay(alignment: .bottom) { Hairline(color: Color.white.opacity(0.06)) }
+        .overlay(alignment: .trailing) { Hairline(color: Color.white.opacity(0.06), vertical: true) }
+        .contentShape(Rectangle())
     }
 
     private func assistantHelp(_ assistant: Assistant, has: Bool) -> String {

--- a/Sources/LoadoutApp/SettingsPane.swift
+++ b/Sources/LoadoutApp/SettingsPane.swift
@@ -25,7 +25,7 @@ struct SettingsPane: View {
     }
 
     enum Section: String, CaseIterable, Identifiable {
-        case projects, appearance, usage, assistants, storage, help
+        case projects, appearance, usage, assistants, storage, updates, help
 
         var id: String { rawValue }
 
@@ -36,6 +36,7 @@ struct SettingsPane: View {
             case .usage: return "Usage"
             case .assistants: return "Assistants"
             case .storage: return "Storage"
+            case .updates: return "Updates"
             case .help: return "Help"
             }
         }
@@ -47,6 +48,7 @@ struct SettingsPane: View {
             case .usage: return "chart.bar"
             case .assistants: return "person.2"
             case .storage: return "internaldrive"
+            case .updates: return "arrow.down.circle"
             case .help: return "questionmark.circle"
             }
         }
@@ -191,6 +193,7 @@ struct SettingsPane: View {
                 case .usage: UsageTab(model: model)
                 case .assistants: AssistantsTab(model: model)
                 case .storage: StorageSettings(model: model)
+                case .updates: UpdatesTab()
                 case .help: HelpTab(model: model)
                 }
             }

--- a/Sources/LoadoutApp/SettingsView.swift
+++ b/Sources/LoadoutApp/SettingsView.swift
@@ -19,6 +19,8 @@ struct SettingsView: View {
                 .tabItem { Label("Assistants", systemImage: "person.2") }
             StorageTab(model: model)
                 .tabItem { Label("Storage", systemImage: "internaldrive") }
+            UpdatesTab()
+                .tabItem { Label("Updates", systemImage: "arrow.down.circle") }
             HelpTab(model: model)
                 .tabItem { Label("Help", systemImage: "questionmark.circle") }
         }
@@ -379,6 +381,98 @@ private struct UsageSourceRow: View {
             return "There is history here, but nothing in it proves a skill was used, so it "
                 + "contributes nothing rather than a misleading zero."
         case .error(let message): return message
+        }
+    }
+}
+
+// MARK: - Updates
+
+/// The visible half of the update check: which version is running, whether the daily check is on,
+/// and a button that answers now.
+///
+/// The answer lands in the pane rather than in a window, because somebody who pressed a button in
+/// Settings is already looking at the place the answer belongs — and a pane cannot block the app
+/// the way an alert can. The question itself is the same one the menu item asks: UpdateCheck.
+struct UpdatesTab: View {
+    @AppStorage(UpdateNotice.automaticKey) private var checksAutomatically = true
+    @State private var isChecking = false
+    @State private var answer: Answer?
+
+    /// What the pane can say: UpdateCheck's three outcomes, plus the one this side decides — a
+    /// build run from source, which has no version to compare in the first place.
+    private enum Answer {
+        case outcome(UpdateCheck.Outcome, running: String)
+        case unreleasedBuild
+    }
+
+    var body: some View {
+        Form {
+            LabeledContent("Version", value: UpdateCheck.runningVersion() ?? "Unreleased build")
+
+            Toggle("Check for a new version once a day", isOn: $checksAutomatically)
+                .help(
+                    "Asks github.com for the latest release number, at most once a day. "
+                        + "No files, no identifiers — and off means Loadout makes no network calls at all."
+                )
+
+            HStack {
+                if isChecking {
+                    ProgressView().controlSize(.small)
+                    Text("Checking…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Check now") { check() }
+                    .disabled(isChecking)
+                    .help("Ask GitHub right now, whether or not the daily check is on")
+                    .pointingHand()
+            }
+
+            if let answer, !isChecking {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(message(for: answer))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if case .outcome(.available(let update), _) = answer {
+                        Button("Open release page") { NSWorkspace.shared.open(update.page) }
+                            .pointingHand()
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    /// Loadout never installs anything for you, so the new-version line says what to do next
+    /// rather than pretending a button here could do it — and a check that never reached GitHub
+    /// says so, instead of passing itself off as good news.
+    private func message(for answer: Answer) -> String {
+        switch answer {
+        case .outcome(.available(let update), _):
+            "Loadout \(update.version) is out. Download it and drag it over the copy in Applications."
+        case .outcome(.upToDate, let running):
+            "Loadout \(running) is the latest version."
+        case .outcome(.unreachable, _):
+            "Couldn't check for updates — GitHub could not be reached. Try again in a moment."
+        case .unreleasedBuild:
+            "This build has no version number, so there is nothing to compare — version checks only work on a released build."
+        }
+    }
+
+    private func check() {
+        isChecking = true
+        Task {
+            if let running = UpdateCheck.runningVersion() {
+                let outcome = await UpdateCheck.check(against: running)
+                // The launch notice must not raise this same version later: it has been shown.
+                if case .available(let update) = outcome { UpdateNotice.noteShown(update.version) }
+                answer = .outcome(outcome, running: running)
+            } else {
+                answer = .unreleasedBuild
+            }
+            isChecking = false
         }
     }
 }

--- a/Sources/LoadoutApp/UpdateNotice.swift
+++ b/Sources/LoadoutApp/UpdateNotice.swift
@@ -14,20 +14,46 @@ import LoadoutCore
 enum UpdateNotice {
     /// The last version the launch check mentioned, so it does not mention it again.
     private static let announcedKey = "lastAnnouncedUpdate"
+    /// The switch in Settings › Updates. On by default, and read before the request is built, so
+    /// off means Loadout makes no network call at all.
+    static let automaticKey = "checksForUpdates"
+    /// When the launch check last ran. Opening the app ten times in a morning is still one request.
+    private static let lastCheckKey = "lastUpdateCheck"
+
+    /// Roughly a day, and short of it on purpose: exactly 24h means somebody who opens Loadout
+    /// each morning at the same time never gets a second check.
+    private static let interval: TimeInterval = 20 * 60 * 60
+
+    static var checksAutomatically: Bool {
+        get { UserDefaults.standard.object(forKey: automaticKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: automaticKey) }
+    }
 
     /// Runs shortly after launch, and only ever opens a window for a version it has not raised
     /// before. Never blocks the launch: it is a detached task, and a failed check says nothing.
     static func checkOnLaunch() {
+        guard checksAutomatically else { return }
+        let last = UserDefaults.standard.object(forKey: lastCheckKey) as? Date ?? .distantPast
+        guard Date().timeIntervalSince(last) > interval else { return }
+        guard let running = UpdateCheck.runningVersion() else { return }
         Task {
-            guard let update = await UpdateCheck.newerRelease() else { return }
-            guard UserDefaults.standard.string(forKey: announcedKey) != update.version else { return }
+            let outcome = await UpdateCheck.check(against: running)
+            // Only an answer starts the clock. A check that never reached GitHub taught nobody
+            // anything, so the next launch asks again rather than waiting out the day.
+            guard outcome != .unreachable else { return }
+            UserDefaults.standard.set(Date(), forKey: lastCheckKey)
+            guard case .available(let update) = outcome,
+                  UserDefaults.standard.string(forKey: announcedKey) != update.version
+            else { return }
             UserDefaults.standard.set(update.version, forKey: announcedKey)
             present(update)
         }
     }
 
-    /// The Loadout menu's "Check for Updates…", which answers either way.
+    /// The Loadout menu's "Check for Updates…", which answers either way. Somebody asked, so it
+    /// ignores both the once-a-day throttle and the switch: those govern the uninvited check.
     static func checkNow() {
+        UserDefaults.standard.set(Date(), forKey: lastCheckKey)
         Task {
             guard let running = UpdateCheck.runningVersion() else {
                 // A build that was never packaged has no version to compare — say that rather
@@ -38,13 +64,27 @@ enum UpdateNotice {
                     link: true
                 )
             }
-            if let update = await UpdateCheck.newerRelease(than: running) {
+            switch await UpdateCheck.check(against: running) {
+            case .available(let update):
                 UserDefaults.standard.set(update.version, forKey: announcedKey)
                 present(update)
-            } else {
+            case .upToDate:
                 say("Loadout \(running) is the latest version", "You're up to date.", link: false)
+            case .unreachable:
+                say(
+                    "Couldn't check for updates",
+                    "GitHub could not be reached. Try again in a moment.",
+                    link: false
+                )
             }
         }
+    }
+
+    /// Settings › Updates asks the same question but shows the answer in the pane instead of a
+    /// window, so it records what it found here — otherwise the launch notice would later raise a
+    /// version somebody has already been shown.
+    static func noteShown(_ version: String) {
+        UserDefaults.standard.set(version, forKey: announcedKey)
     }
 
     /// The one that matters: a new version exists, here is what it is, and here is the way to it.

--- a/Sources/LoadoutCore/AssistantCLI.swift
+++ b/Sources/LoadoutCore/AssistantCLI.swift
@@ -57,16 +57,26 @@ public struct AssistantCLI: Identifiable, Hashable, Sendable {
     /// The CLI's own directory goes first, because an nvm-installed codex sits in the same folder
     /// as the node that has to run it, and the usual install locations follow.
     public var environment: [String: String] {
-        var environment = ProcessInfo.processInfo.environment
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        environment(
+            base: ProcessInfo.processInfo.environment,
+            home: FileManager.default.homeDirectoryForCurrentUser
+        )
+    }
+
+    /// The same rule, with the two things it reads from the machine passed in, so a test can
+    /// reproduce the bare `PATH` a Finder-launched app inherits without touching the real one.
+    public func environment(base: [String: String], home: URL) -> [String: String] {
+        var environment = base
         var directories = [executable.deletingLastPathComponent().path]
-        directories += (environment["PATH"] ?? "").split(separator: ":").map(String.init)
+        directories += (base["PATH"] ?? "").split(separator: ":").map(String.init)
         directories += [
-            "\(home)/.local/bin", "\(home)/.opencode/bin",
+            "\(home.path)/.local/bin", "\(home.path)/.opencode/bin",
             "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin",
         ]
         var seen = Set<String>()
-        environment["PATH"] = directories.filter { seen.insert($0).inserted }.joined(separator: ":")
+        environment["PATH"] = directories
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+            .joined(separator: ":")
         return environment
     }
 
@@ -143,7 +153,14 @@ public enum AssistantCLIRegistry {
     /// Verified non-interactive syntax for each, as of the CLIs on this machine today.
     private static let builtins: [Builtin] = [
         Builtin(id: "claude", binaryName: "claude", label: "Claude Code", argumentTemplate: "-p {prompt}"),
-        Builtin(id: "codex", binaryName: "codex", label: "Codex", argumentTemplate: "exec {prompt}"),
+        // `--skip-git-repo-check` is not optional: `codex exec` refuses to start in a directory
+        // that is neither a git repository nor listed as trusted in `~/.codex/config.toml`, and a
+        // skill folder is normally neither. Without it every Ask ends in "Not inside a trusted
+        // directory and --skip-git-repo-check was not specified."
+        Builtin(
+            id: "codex", binaryName: "codex", label: "Codex",
+            argumentTemplate: "exec --skip-git-repo-check {prompt}"
+        ),
         Builtin(
             id: "cursor-agent", binaryName: "cursor-agent", label: "Cursor",
             argumentTemplate: "-p --output-format text {prompt}"
@@ -212,6 +229,11 @@ public enum AssistantCLIRegistry {
         ]
         if let nvmDirs = try? fm.contentsOfDirectory(atPath: "\(home)/.nvm/versions/node") {
             candidates += nvmDirs.map { "\(home)/.nvm/versions/node/\($0)/bin/\(name)" }
+        }
+        // Last resort for Codex: the ChatGPT app ships its own native `codex`. A machine with the
+        // app but no npm install still gets an Ask target, and that copy needs no Node at all.
+        if name == "codex" {
+            candidates.append("/Applications/ChatGPT.app/Contents/Resources/codex")
         }
         for candidate in candidates where fm.isExecutableFile(atPath: candidate) {
             return URL(fileURLWithPath: candidate)

--- a/Sources/LoadoutCore/Copilot.swift
+++ b/Sources/LoadoutCore/Copilot.swift
@@ -23,11 +23,14 @@ public final class Copilot: @unchecked Sendable {
     ///   - prompt: what to ask.
     ///   - directory: the working directory, normally the skill's own folder.
     ///   - timeout: hard ceiling; the child is killed when it expires (AC7.4).
+    ///   - environment: what the child runs with. The default widens `PATH` so a CLI that is a
+    ///     script can find its own interpreter — see `AssistantCLIEnvironment`. Tests override it.
     public func run(
         cli: AssistantCLI?,
         prompt: String,
         in directory: URL,
-        timeout: TimeInterval = 180
+        timeout: TimeInterval = 180,
+        environment: [String: String]? = nil
     ) throws -> Result {
         guard let cli else { throw LoadoutError.claudeNotFound }
 
@@ -35,10 +38,14 @@ public final class Copilot: @unchecked Sendable {
         task.executableURL = cli.executable
         task.arguments = cli.arguments(for: prompt)
         task.currentDirectoryURL = directory
-        task.environment = cli.environment
+        task.environment = environment ?? cli.environment
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = pipe
+        // The question is an argument, never something typed in. `codex exec` reads stdin when it
+        // is not a terminal and waits for EOF, so an inherited stdin that never closes would hang
+        // the run until the timeout kills it.
+        task.standardInput = FileHandle.nullDevice
 
         lock.lock()
         process = task

--- a/Sources/LoadoutCore/InventoryScanner.swift
+++ b/Sources/LoadoutCore/InventoryScanner.swift
@@ -93,18 +93,38 @@ public struct InventoryScanner: Sendable {
         return byName.values.sorted { $0.name < $1.name }
     }
 
-    /// Everything parked in a `skills-off`, wherever it is parked.
+    /// Everything parked in a `skills-off`, wherever it is parked, minus whatever the matching
+    /// live `skills` directory still provides.
     ///
-    /// One per assistant plus the shared store, because a disabled skill stays with its owner: a
-    /// Codex skill waits in `~/.codex/skills-off`, and reading only Claude's would make it look
-    /// deleted.
+    /// One pair of directories per assistant plus the shared store, because a disabled skill stays
+    /// with its owner: a Codex skill waits in `~/.codex/skills-off`, and reading only Claude's
+    /// would make it look deleted.
+    ///
+    /// Within one assistant, though, the same skill can be readable in both of its directories at
+    /// once — disabling copies the folder aside, and a re-enable that leaves the copy behind makes
+    /// it turn up twice. Both readings are the same skill and carry the same id, so listing both
+    /// put two rows with one identity into the list: `ForEach` draws one of them and leaves an
+    /// empty slot the size of the other, and every count is one too high. The live folder is what
+    /// decides whether anything loads the skill, so that is the reading kept.
+    ///
+    /// The check is per assistant on purpose. A skill live in Codex and parked in Claude is two
+    /// different things wearing one name, and the parked one still needs its row — that is the
+    /// only row from which it can be put back.
     func disabledSkills() -> [Item] {
-        var roots = assistants.map { $0.skillsRoot.deletingLastPathComponent().appendingPathComponent("skills-off") }
-        roots.append(paths.sharedSkills.deletingLastPathComponent().appendingPathComponent("skills-off"))
+        var roots = assistants.map {
+            (live: $0.skillsRoot,
+             off: $0.skillsRoot.deletingLastPathComponent().appendingPathComponent("skills-off"))
+        }
+        roots.append(
+            (live: paths.sharedSkills,
+             off: paths.sharedSkills.deletingLastPathComponent().appendingPathComponent("skills-off"))
+        )
 
         var byName: [String: Item] = [:]
         for root in roots {
-            for folder in skillFolders(in: root) where byName[folder.lastPathComponent] == nil {
+            let live = Set(skillFolders(in: root.live).map(\.lastPathComponent))
+            for folder in skillFolders(in: root.off) where byName[folder.lastPathComponent] == nil {
+                guard !live.contains(folder.lastPathComponent) else { continue }
                 byName[folder.lastPathComponent] = skill(at: folder, origin: .personal, enabled: false)
             }
         }

--- a/Sources/LoadoutCore/UpdateCheck.swift
+++ b/Sources/LoadoutCore/UpdateCheck.swift
@@ -37,16 +37,24 @@ public enum UpdateCheck {
         return raw
     }
 
-    /// Asks GitHub what the newest release is, and answers with it only when it is newer than what
-    /// is running. Any failure — offline, rate-limited, GitHub down — answers nil: a version check
-    /// that interrupts somebody because their café wifi dropped is worse than no version check.
+    /// What asking GitHub can end in. "Up to date" and "could not ask" are different facts and are
+    /// kept apart here, because telling somebody they are on the latest version when the question
+    /// never left the machine is the one lie this whole file exists to avoid.
+    public enum Outcome: Equatable, Sendable {
+        case available(Available)
+        case upToDate
+        /// Offline, rate-limited, non-200, a payload that changed shape — every way of not knowing.
+        case unreachable
+    }
+
+    /// Asks GitHub what the newest release is and says which of the three it is. Nothing throws its
+    /// way out to the person using the app: a failure is a state to report, not an error to raise.
     ///
-    /// - Parameter current: defaults to the running bundle's version.
-    public static func newerRelease(
-        than current: String? = runningVersion(),
+    /// - Parameter current: the running version, "0.3.1" or "v0.3.1".
+    public static func check(
+        against current: String,
         session: URLSession = .shared
-    ) async -> Available? {
-        guard let current else { return nil }
+    ) async -> Outcome {
         var request = URLRequest(url: latestReleaseAPI)
         // GitHub asks for these two by name and answers unversioned requests less predictably.
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
@@ -56,9 +64,25 @@ public enum UpdateCheck {
         guard let (data, response) = try? await session.data(for: request),
               let http = response as? HTTPURLResponse, http.statusCode == 200,
               let release = try? JSONDecoder().decode(Release.self, from: data)
-        else { return nil }
+        else { return .unreachable }
 
-        return available(from: release, current: current)
+        return available(from: release, current: current).map(Outcome.available) ?? .upToDate
+    }
+
+    /// The older shape of the same question, for callers that only act when there is something to
+    /// download. A failed check and an up-to-date app both answer nil here, which is why anything
+    /// that has to tell a person what happened should ask `check(against:)` instead.
+    ///
+    /// - Parameter current: defaults to the running bundle's version.
+    public static func newerRelease(
+        than current: String? = runningVersion(),
+        session: URLSession = .shared
+    ) async -> Available? {
+        guard let current else { return nil }
+        guard case .available(let update) = await check(against: current, session: session) else {
+            return nil
+        }
+        return update
     }
 
     /// The decision itself, split out from the network so it can be tested without one.

--- a/Tests/LoadoutCoreTests/AssistantCLITests.swift
+++ b/Tests/LoadoutCoreTests/AssistantCLITests.swift
@@ -9,12 +9,12 @@ final class AssistantCLITests: XCTestCase {
     func testArgvForEachOfTheFourBuiltInShapes() {
         let executable = URL(fileURLWithPath: "/usr/local/bin/thing")
         let claude = AssistantCLI(id: "claude", label: "Claude Code", executable: executable, argumentTemplate: "-p {prompt}", isCustom: false)
-        let codex = AssistantCLI(id: "codex", label: "Codex", executable: executable, argumentTemplate: "exec {prompt}", isCustom: false)
+        let codex = AssistantCLI(id: "codex", label: "Codex", executable: executable, argumentTemplate: "exec --skip-git-repo-check {prompt}", isCustom: false)
         let cursor = AssistantCLI(id: "cursor-agent", label: "Cursor", executable: executable, argumentTemplate: "-p --output-format text {prompt}", isCustom: false)
         let opencode = AssistantCLI(id: "opencode", label: "opencode", executable: executable, argumentTemplate: "run {prompt}", isCustom: false)
 
         XCTAssertEqual(claude.arguments(for: "hello"), ["-p", "hello"])
-        XCTAssertEqual(codex.arguments(for: "hello"), ["exec", "hello"])
+        XCTAssertEqual(codex.arguments(for: "hello"), ["exec", "--skip-git-repo-check", "hello"])
         XCTAssertEqual(cursor.arguments(for: "hello"), ["-p", "--output-format", "text", "hello"])
         XCTAssertEqual(opencode.arguments(for: "hello"), ["run", "hello"])
     }

--- a/Tests/LoadoutCoreTests/CopilotEnvironmentTests.swift
+++ b/Tests/LoadoutCoreTests/CopilotEnvironmentTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import LoadoutCore
+
+/// Running an assistant CLI from a Mac app, not from a shell.
+///
+/// A Finder-launched app inherits launchd's `PATH` — `/usr/bin:/bin:/usr/sbin:/sbin` — and
+/// nothing else. `codex` is a `#!/usr/bin/env node` script installed under nvm, so with that
+/// `PATH` it never starts: `env` cannot find `node` and the run dies with exit code 127.
+/// These tests reproduce that with a script CLI of their own, so no real assistant is invoked.
+final class CopilotEnvironmentTests: XCTestCase {
+    private let fm = FileManager.default
+    private var root: URL!
+
+    /// What a Finder-launched app actually gets, and what these tests use as the base.
+    private let launchdPath = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+    override func setUpWithError() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("loadout-copilot-\(UUID().uuidString.prefix(8))")
+        try fm.createDirectory(at: root.appendingPathComponent("bin"), withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? fm.removeItem(at: root)
+    }
+
+    // MARK: - The interpreter has to be reachable
+
+    func testAScriptCLIRunsWhenItsInterpreterOnlySitsBesideIt() throws {
+        let cli = makeInterpretedCLI()
+
+        let result = try Copilot().run(
+            cli: cli, prompt: "hello", in: root, timeout: 30,
+            environment: cli.environment(base: ["PATH": launchdPath], home: root)
+        )
+
+        XCTAssertEqual(result.exitCode, 0, "the interpreter has to be found: \(result.output)")
+        XCTAssertTrue(result.output.contains("ok run hello"), "unexpected output: \(result.output)")
+    }
+
+    /// The bug itself: hand the child the bare `PATH` and it dies before parsing an argument.
+    func testTheSameCLIDiesWithTheBarePathAFinderLaunchedAppInherits() throws {
+        let cli = makeInterpretedCLI()
+
+        let result = try Copilot().run(
+            cli: cli, prompt: "hello", in: root, timeout: 30, environment: ["PATH": launchdPath]
+        )
+
+        XCTAssertEqual(result.exitCode, 127, "this is the failure mode the fix avoids")
+        XCTAssertTrue(
+            result.output.contains("No such file or directory"),
+            "expected env's complaint: \(result.output)"
+        )
+    }
+
+    func testTheExecutablesOwnDirectoryLeadsThePath() {
+        let cli = AssistantCLI(
+            id: "thing", label: "Thing", executable: root.appendingPathComponent("bin/thing"),
+            argumentTemplate: "{prompt}", isCustom: true
+        )
+
+        let path = cli.environment(base: ["PATH": launchdPath], home: root)["PATH"] ?? ""
+
+        XCTAssertEqual(
+            path.split(separator: ":").first.map(String.init),
+            root.appendingPathComponent("bin").path
+        )
+        XCTAssertTrue(path.contains("/usr/bin"), "what was already there is not lost")
+    }
+
+    func testThePathKeepsEachDirectoryOnlyOnce() {
+        let cli = AssistantCLI(
+            id: "thing", label: "Thing", executable: URL(fileURLWithPath: "/usr/local/bin/thing"),
+            argumentTemplate: "{prompt}", isCustom: true
+        )
+
+        let path = cli.environment(
+            base: ["PATH": "/usr/local/bin:/usr/bin:/bin"], home: root
+        )["PATH"] ?? ""
+
+        let directories = path.split(separator: ":").map(String.init)
+        XCTAssertEqual(Set(directories).count, directories.count, "no duplicates: \(path)")
+        XCTAssertEqual(directories.first, "/usr/local/bin")
+    }
+
+    func testEverythingElseInTheEnvironmentSurvives() {
+        let cli = AssistantCLI(
+            id: "thing", label: "Thing", executable: root.appendingPathComponent("bin/thing"),
+            argumentTemplate: "{prompt}", isCustom: true
+        )
+
+        let environment = cli.environment(base: ["PATH": launchdPath, "HOME": root.path], home: root)
+
+        XCTAssertEqual(environment["HOME"], root.path, "only PATH is widened")
+    }
+
+    // MARK: - Nothing is fed on stdin
+
+    /// `codex exec` reads stdin whenever it is not a terminal and waits for EOF. Inheriting the
+    /// app's stdin would hang the run until the timeout killed it.
+    func testTheChildGetsNoStdin() throws {
+        let script = root.appendingPathComponent("bin/reader")
+        try "#!/bin/sh\ninput=$(cat)\necho \"stdin=[$input]\"\n".write(to: script, atomically: true, encoding: .utf8)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+        let cli = AssistantCLI(
+            id: "reader", label: "Reader", executable: script,
+            argumentTemplate: "{prompt}", isCustom: true
+        )
+
+        let result = try Copilot().run(
+            cli: cli, prompt: "hello", in: root, timeout: 20, environment: ["PATH": launchdPath]
+        )
+
+        XCTAssertFalse(result.timedOut, "it read stdin and waited for an EOF that never came")
+        XCTAssertTrue(result.output.contains("stdin=[]"), "unexpected output: \(result.output)")
+    }
+
+    // MARK: - Codex's own invocation
+
+    /// `codex exec` refuses to start in a folder that is neither a git repository nor trusted in
+    /// `~/.codex/config.toml`, which is what a skill folder normally is.
+    func testTheCodexBuiltInSkipsTheGitRepositoryCheck() throws {
+        let fake = root.appendingPathComponent("bin/codex")
+        try "#!/bin/sh\nexit 0\n".write(to: fake, atomically: true, encoding: .utf8)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fake.path)
+
+        let found = AssistantCLIRegistry.discover(customEntries: []) { $0 == "codex" ? fake : nil }
+        let codex = try XCTUnwrap(found.first { $0.id == "codex" })
+
+        XCTAssertEqual(
+            codex.arguments(for: "hello"), ["exec", "--skip-git-repo-check", "hello"],
+            "the flag comes before the prompt, which is always the last argument"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// A CLI shaped like the real `codex`: a script whose `#!/usr/bin/env <interpreter>` line can
+    /// only be resolved if the interpreter's directory is on `PATH`.
+    private func makeInterpretedCLI() -> AssistantCLI {
+        let bin = root.appendingPathComponent("bin")
+        let interpreter = bin.appendingPathComponent("loadout-fake-node")
+        try! "#!/bin/sh\nshift\necho \"ok $*\"\n".write(to: interpreter, atomically: true, encoding: .utf8)
+        try! fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: interpreter.path)
+
+        let script = bin.appendingPathComponent("faux-codex")
+        try! "#!/usr/bin/env loadout-fake-node\n// never read by the fake interpreter\n"
+            .write(to: script, atomically: true, encoding: .utf8)
+        try! fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+
+        return AssistantCLI(
+            id: "faux-codex", label: "Faux Codex", executable: script,
+            argumentTemplate: "run {prompt}", isCustom: false
+        )
+    }
+}

--- a/Tests/LoadoutCoreTests/InventoryTests.swift
+++ b/Tests/LoadoutCoreTests/InventoryTests.swift
@@ -126,6 +126,34 @@ final class InventoryTests: XCTestCase {
         XCTAssertEqual(items.first { $0.name == "ativa" }?.enabled, true)
     }
 
+    /// A skill can be readable in both places at once: disabling copies the folder into
+    /// `skills-off`, and a re-enable that leaves the copy behind makes the same skill turn up
+    /// twice. Both readings carry the same id, so the list held two rows with one identity —
+    /// which the list draws as one row followed by an empty slot the size of the other, and
+    /// counts as two skills.
+    func testSkillPresentInBothPlacesIsListedOnceAsEnabled() {
+        let fixture = Fixture()
+        fixture.skill("alone")
+        fixture.skill("in-both")
+        fixture.skill("in-both", disabled: true)
+        fixture.skill("parked", disabled: true)
+
+        let skills = InventoryScanner(paths: fixture.paths).scanAll().items.filter { $0.kind == .skill }
+
+        XCTAssertEqual(skills.map(\.id).count, Set(skills.map(\.id)).count, "the list holds one row per skill")
+        XCTAssertEqual(skills.map(\.name).sorted(), ["alone", "in-both", "parked"])
+
+        // The live folder is what decides whether anything loads it, so that is the reading kept:
+        // enabled, and pointing at the file the detail pane opens and the switch acts on.
+        let both = skills.first { $0.name == "in-both" }
+        XCTAssertEqual(both?.enabled, true)
+        XCTAssertEqual(
+            both?.directory?.resolvingSymlinksInPath(),
+            fixture.paths.skills.appendingPathComponent("in-both").resolvingSymlinksInPath()
+        )
+        XCTAssertEqual(skills.first { $0.name == "parked" }?.enabled, false)
+    }
+
     // MARK: AC1.4
 
     func testPluginSkillsAreAttributedToTheirPlugin() {

--- a/Tests/LoadoutCoreTests/UpdateCheckTests.swift
+++ b/Tests/LoadoutCoreTests/UpdateCheckTests.swift
@@ -46,4 +46,72 @@ final class UpdateCheckTests: XCTestCase {
         let page = "https://github.com/migsilva89/loadout/releases/tag/v0.2.0"
         XCTAssertEqual(UpdateCheck.available(from: release("v0.2.0", page: page), current: "0.1.0")?.page.absoluteString, page)
     }
+
+    // MARK: - The three outcomes, over a stubbed network
+
+    /// "Up to date" and "couldn't ask" used to be the same nil. They are different facts — one is
+    /// GitHub answering, the other is never having reached it — and a pane that says "you're on
+    /// the latest version" when the request failed is lying to somebody who asked a plain question.
+    func testGitHubAnsweringWithANewerTagIsAnUpdate() async {
+        let outcome = await check(status: 200, body: #"{"tag_name":"v0.2.0","html_url":"https://example.com/r"}"#)
+        XCTAssertEqual(outcome, .available(UpdateCheck.Available(version: "0.2.0", page: URL(string: "https://example.com/r")!)))
+    }
+
+    func testGitHubAnsweringWithTheSameTagIsUpToDate() async {
+        let outcome = await check(status: 200, body: #"{"tag_name":"v0.1.0","html_url":"https://example.com/r"}"#)
+        XCTAssertEqual(outcome, .upToDate)
+    }
+
+    /// Offline, and the case that matters most: silence is not agreement.
+    func testANetworkErrorIsUnreachableRatherThanUpToDate() async {
+        let outcome = await check(error: URLError(.notConnectedToInternet))
+        XCTAssertEqual(outcome, .unreachable)
+    }
+
+    /// Rate limiting is GitHub's usual way of saying no, and it arrives as a perfectly valid body.
+    func testANon200IsUnreachable() async {
+        let outcome = await check(status: 403, body: #"{"message":"API rate limit exceeded"}"#)
+        XCTAssertEqual(outcome, .unreachable)
+    }
+
+    func testAPayloadThatIsNotTheExpectedShapeIsUnreachable() async {
+        let notJSON = await check(status: 200, body: "<html>502 Bad Gateway</html>")
+        XCTAssertEqual(notJSON, .unreachable)
+        let missingTheTag = await check(status: 200, body: #"{"name":"0.2.0"}"#)
+        XCTAssertEqual(missingTheTag, .unreachable)
+    }
+
+    /// Runs the real `check(against:)` against a stubbed URLSession, so every branch above is the
+    /// shipping code path and not a rehearsal of it.
+    private func check(status: Int = 200, body: String = "", error: URLError? = nil) async -> UpdateCheck.Outcome {
+        StubProtocol.answer = (status, Data(body.utf8), error)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubProtocol.self]
+        return await UpdateCheck.check(against: "0.1.0", session: URLSession(configuration: configuration))
+    }
+}
+
+/// Answers whatever the test last set, so no test here touches the network.
+private final class StubProtocol: URLProtocol {
+    /// One test runs at a time and each sets this before asking; the unchecked annotation is that
+    /// fact written down, not a claim that this would be safe under concurrency.
+    nonisolated(unsafe) static var answer: (status: Int, body: Data, error: URLError?) = (200, Data(), nil)
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        let answer = Self.answer
+        if let error = answer.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: answer.status, httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: answer.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
 }


### PR DESCRIPTION
Four independent bugs, one commit each.

**Ask never reached the Codex CLI.** A Finder-launched app inherits launchd's PATH, which has no `node`, so the nvm-installed `codex` script died with exit 127 before it ran. `codex exec` also refuses a folder that is not a git repository — every skill folder — and blocks on stdin when it is not a terminal. The launched executable's own directory now leads the child PATH, the template passes `--skip-git-repo-check`, stdin is closed, and detection falls back to the `codex` binary inside ChatGPT.app.

**A skill in two places was listed twice.** One present both in a live `skills` directory and in that assistant's `skills-off` was emitted as two items sharing an id. SwiftUI drew one row and left a hole the size of its twin, and the header counted it twice. The live copy now wins, compared per assistant so a skill parked under one assistant and live under another keeps both rows.

**The app offered a removal it would then refuse.** Removing an item from its only assistant would delete it, so the click raised an error. That assistant's remove action is now disabled and dimmed, with the reason on hover; the check stays visible and the guard in `Mutations` stays as a safety net.

**An offline app claimed to be up to date.** The check returned nil both for up to date and for unreachable. It now reports the three outcomes explicitly, says so honestly in a new Settings tab beside the running version and a manual check, and throttles the launch check to once a day without burning that window when the check failed.

311 tests, 0 failures.